### PR TITLE
feat!: enable and request miner interval for setup local

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ ARGUMENTS
 OPTIONS
   -i, --external-ip=external-ip                            external ip
   -k, --operator-bls-private-key=operator-bls-private-key  operator bls private key
+  -m, --miner-interval=miner-interval                      interval between blocks
   -p, --funding-private-key=funding-private-key            private key with more than 1000 dash for funding collateral
   -v, --verbose                                            use verbose mode for output
-  --miner-interval=miner-interval                          interval between blocks
   --node-count=node-count                                  number of nodes to setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ OPTIONS
   -k, --operator-bls-private-key=operator-bls-private-key  operator bls private key
   -p, --funding-private-key=funding-private-key            private key with more than 1000 dash for funding collateral
   -v, --verbose                                            use verbose mode for output
+  --miner-interval=miner-interval                          interval between blocks
   --node-count=node-count                                  number of nodes to setup
 ```
 

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -130,7 +130,7 @@ SetupCommand.flags = {
   'operator-bls-private-key': flagTypes.string({ char: 'k', description: 'operator bls private key' }),
   'funding-private-key': flagTypes.string({ char: 'p', description: `private key with more than ${MASTERNODE_DASH_AMOUNT} dash for funding collateral` }),
   'node-count': flagTypes.integer({ description: 'number of nodes to setup', default: null }),
-  'miner-interval': flagTypes.string({ description: 'interval between blocks', default: null }),
+  'miner-interval': flagTypes.string({ char: 'm', description: 'interval between blocks', default: null }),
   verbose: flagTypes.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
 };
 

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -33,6 +33,7 @@ class SetupCommand extends BaseCommand {
       'operator-bls-private-key': operatorBlsPrivateKey,
       'funding-private-key': fundingPrivateKeyString,
       'node-count': nodeCount,
+      'miner-interval': minerInterval,
       verbose: isVerbose,
     },
     generateBlsKeys,
@@ -95,6 +96,7 @@ class SetupCommand extends BaseCommand {
         preset,
         nodeType,
         nodeCount,
+        minerInterval,
         externalIp,
         operatorBlsPrivateKey,
         fundingPrivateKeyString,
@@ -128,6 +130,7 @@ SetupCommand.flags = {
   'operator-bls-private-key': flagTypes.string({ char: 'k', description: 'operator bls private key' }),
   'funding-private-key': flagTypes.string({ char: 'p', description: `private key with more than ${MASTERNODE_DASH_AMOUNT} dash for funding collateral` }),
   'node-count': flagTypes.integer({ description: 'number of nodes to setup', default: null }),
+  'miner-interval': flagTypes.string({ description: 'interval between blocks', default: null }),
   verbose: flagTypes.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
 };
 

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -45,7 +45,7 @@ function setupLocalPresetTaskFactory(
         task: async (ctx, task) => {
           ctx.minerInterval = await task.prompt({
             type: 'input',
-            message: 'Enter the interval between blocks',
+            message: 'Enter the interval between core blocks',
             initial: configFile.getConfig('base').options.core.miner.interval,
             validate: (state) => {
               if (state.match(/\d+(\.\d+)?(m|s)/)) {

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -40,6 +40,24 @@ function setupLocalPresetTaskFactory(
         },
       },
       {
+        title: 'Set the miner interval',
+        enabled: (ctx) => ctx.minerInterval === null,
+        task: async (ctx, task) => {
+          ctx.minerInterval = await task.prompt({
+            type: 'input',
+            message: 'Enter the interval between blocks',
+            initial: configFile.getConfig('base').options.core.miner.interval,
+            validate: (state) => {
+              if (state.match(/\d+(\.\d+)?(m|s)/)) {
+                return true;
+              }
+
+              return 'Please enter a valid integer or decimal duration with m or s units';
+            },
+          });
+        },
+      },
+      {
         title: 'Create local group configs',
         task: (ctx) => {
           ctx.configGroup = new Array(ctx.nodeCount)
@@ -68,6 +86,8 @@ function setupLocalPresetTaskFactory(
                   config.set('description', 'seed node for local network');
 
                   config.set('core.masternode.enable', false);
+                  config.set('core.miner.enable', true);
+                  config.set('core.miner.interval', ctx.minerInterval);
 
                   // Disable platform for the seed node
                   config.set('platform', undefined);

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -40,7 +40,7 @@ function setupLocalPresetTaskFactory(
         },
       },
       {
-        title: 'Set the miner interval',
+        title: 'Set the core miner interval',
         enabled: (ctx) => ctx.minerInterval === null,
         task: async (ctx, task) => {
           ctx.minerInterval = await task.prompt({

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -86,6 +86,8 @@ function setupLocalPresetTaskFactory(
                   config.set('description', 'seed node for local network');
 
                   config.set('core.masternode.enable', false);
+
+                  // Enable miner for the seed node
                   config.set('core.miner.enable', true);
                   config.set('core.miner.interval', ctx.minerInterval);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable the core miner and set the interval for a network created with `setup local`

## What was done?
<!--- Describe your changes in detail -->
- Add flag to specify interval
- Add step to query mining interval if not specified
- Add basic validation (integer/decimal + `m` or `s` unit)
- Show default from base config
- Miner is now always enabled on seed node for all local configs (should this be optional?)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with various values, network creates blocks with that duration

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`setup local` command requests miner interval set

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
