### PR TITLE
fix: wait nodes to be ready

### DIFF
--- a/src/listr/tasks/platform/waitForNodeToBeReadyTaskFactory.js
+++ b/src/listr/tasks/platform/waitForNodeToBeReadyTaskFactory.js
@@ -27,11 +27,11 @@ function waitForNodeToBeReadyTaskFactory(
             const response = await tenderdashRpcClient.request('status', {}).catch(() => {});
 
             if (response) {
-              success = !response.error;
+              success = !response.result.sync_info.catching_up;
             }
 
             if (!success) {
-              await wait(2000);
+              await wait(500);
             }
           } while (!success);
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes the wait for nodes to be ready task complete before Tenderdash is actually caught up.

## What was done?
<!--- Describe your changes in detail -->
- Checked that Tenderdash is not catching up

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Starting nodes with the `wait-for-readiness` option many times.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
