### PR TITLE
fix: reset script aborts if no containers present

### DIFF
--- a/bin/temporary_reset_script.sh
+++ b/bin/temporary_reset_script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 #COLLATERAL_KEY=
 #COLLATERAL_ADDRESS=
 

--- a/bin/temporary_reset_script.sh
+++ b/bin/temporary_reset_script.sh
@@ -21,7 +21,8 @@ CONFIG_NAME="local"
 MASTERNODES_COUNT=3
 
 echo "Removing all docker containers and volumes..."
-docker rm -f -v $(docker ps -a -q); docker volume prune -f; rm -rf ~/.dashmate/
+docker rm -f -v $(docker ps -a -q) || true
+docker system prune -f; rm -rf ~/.dashmate/
 
 if [ $BUILD_DRIVE == true ]
 then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The reset script was aborting halfway through if the output of `$(docker ps -a -q)` was blank

## What was done?
<!--- Describe your changes in detail -->
- Allow `docker rm` command to exit with error and still continue
- Prune `system` instead of just `volumes` (also cleans up networks)
- Add `set -e` to stop script on all errors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and by Discord user Sam8

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
