### PR TITLE
fix: waitForQuorumConnections stuck with more than 3 nodes

### DIFF
--- a/src/core/quorum/waitForQuorumConnections.js
+++ b/src/core/quorum/waitForQuorumConnections.js
@@ -3,7 +3,7 @@ const wait = require('../../util/wait');
 const { LLMQ_TYPE_TEST } = require('../../constants');
 
 /**
- * @param {RpcClient[]} rpcClients
+ * @param {RpcClient} rpcClient
  * @param {number} expectedConnectionsCount
  * @return {Promise<boolean>}
  */

--- a/src/core/quorum/waitForQuorumConnections.js
+++ b/src/core/quorum/waitForQuorumConnections.js
@@ -7,31 +7,25 @@ const { LLMQ_TYPE_TEST } = require('../../constants');
  * @param {number} expectedConnectionsCount
  * @return {Promise<boolean>}
  */
-async function checkQuorumConnections(rpcClients, expectedConnectionsCount) {
-  for (const rpcClient of rpcClients) {
-    const { result: dkgStatus } = await rpcClient.quorum('dkgstatus');
+async function checkQuorumConnections(rpcClient, expectedConnectionsCount) {
+  const { result: dkgStatus } = await rpcClient.quorum('dkgstatus');
 
-    if (Object.keys(dkgStatus.session).length === 0) {
-      continue;
-    }
-
-    const noConnections = dkgStatus.quorumConnections == null;
-    const llmqConnections = dkgStatus.quorumConnections;
-
-    if (noConnections || llmqConnections[LLMQ_TYPE_TEST] == null) {
-      return false;
-    }
-
-    const connectionsCount = llmqConnections[LLMQ_TYPE_TEST]
-      .filter((connection) => connection.connected)
-      .length;
-
-    if (connectionsCount < expectedConnectionsCount) {
-      return false;
-    }
+  if (Object.keys(dkgStatus.session).length === 0) {
+    return false;
   }
 
-  return true;
+  const noConnections = dkgStatus.quorumConnections == null;
+  const llmqConnections = dkgStatus.quorumConnections;
+
+  if (noConnections || llmqConnections[LLMQ_TYPE_TEST] == null) {
+    return false;
+  }
+
+  const connectionsCount = llmqConnections[LLMQ_TYPE_TEST]
+    .filter((connection) => connection.connected)
+    .length;
+
+  return connectionsCount >= expectedConnectionsCount;
 }
 
 /**
@@ -49,15 +43,22 @@ async function waitForQuorumConnections(
   timeout = 300000,
 ) {
   const deadline = Date.now() + timeout;
-  let isReady = false;
+  const readyNodes = new Set();
+  const nodesToWait = 3;
 
-  while (!isReady) {
-    isReady = await checkQuorumConnections(
-      rpcClients,
-      expectedConnectionsCount,
-    );
+  while (readyNodes.size < nodesToWait) {
+    await Promise.all(rpcClients.map(async (rpcClient, i) => {
+      const isReady = await checkQuorumConnections(
+        rpcClient,
+        expectedConnectionsCount,
+      );
 
-    if (!isReady) {
+      if (isReady) {
+        readyNodes.add(i);
+      }
+    }));
+
+    if (readyNodes.size < nodesToWait) {
       await bumpMockTime();
 
       await wait(1000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't need to wait for all nodes in waitForQuorumConnections. This will never ends if we use > 3 nodes.

## What was done?
<!--- Describe your changes in detail -->
waitForQuorumConnections now waits for only 3 nodes


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
