### PR TITLE
revert: waitForInstantLockTimeout option from Dash.Client

### DIFF
--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -51,13 +51,10 @@ function initTaskFactory(
             clientOpts.dapiAddresses = [ctx.dapiAddress];
           }
 
-          const nodeCount = ctx.nodeCount || 1;
-
           const faucetClient = new Dash.Client({
             ...clientOpts,
             wallet: {
               privateKey: ctx.fundingPrivateKeyString,
-              waitForInstantLockTimeout: nodeCount * 60000,
             },
           });
 
@@ -65,7 +62,6 @@ function initTaskFactory(
             ...clientOpts,
             wallet: {
               mnemonic: null,
-              waitForInstantLockTimeout: nodeCount * 60000,
             },
           });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't need to pass waitForInstantLockTimeout option to Dash.Client anymore

## What was done?
<!--- Describe your changes in detail -->
Removed waitForInstantLockTimeout option from Dash.Client

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
