### PR TITLE
fix: windows tmp directory install error

### DIFF
--- a/configs/system/base.js
+++ b/configs/system/base.js
@@ -1,6 +1,7 @@
 const {
   NETWORK_TESTNET,
 } = require('../../src/constants');
+const os = require('os');
 
 module.exports = {
   description: 'base config for use as template',
@@ -91,11 +92,11 @@ module.exports = {
           },
           prettyFile: {
             level: 'silent',
-            path: '/tmp/base-drive-pretty.log',
+            path: path.join(os.tmpdir(), `/base-drive-pretty.log`),
           },
           jsonFile: {
             level: 'silent',
-            path: '/tmp/base-drive-json.json',
+            path: path.join(os.tmpdir(), `/base-drive-json.log`),
           },
         },
       },

--- a/configs/system/base.js
+++ b/configs/system/base.js
@@ -2,6 +2,7 @@ const {
   NETWORK_TESTNET,
 } = require('../../src/constants');
 const os = require('os');
+const path = require('path');
 
 module.exports = {
   description: 'base config for use as template',

--- a/configs/system/testnet.js
+++ b/configs/system/testnet.js
@@ -1,4 +1,6 @@
 const lodashMerge = require('lodash.merge');
+const os = require('os');
+const path = require('path');
 
 const {
   NETWORK_TESTNET,
@@ -41,10 +43,10 @@ module.exports = lodashMerge({}, baseConfig, {
       abci: {
         log: {
           prettyFile: {
-            path: '/tmp/testnet-drive-pretty.log',
+            path: path.join(os.tmpdir(), `/testnet-drive-pretty.log`),
           },
           jsonFile: {
-            path: '/tmp/testnet-drive-json.log',
+            path: path.join(os.tmpdir(), `/testnet-drive-json.log`),
           },
         },
       },

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -19,12 +19,8 @@ services:
       - core
     volumes:
       - drive_abci_data:/usr/src/app/db
-      - type: bind
-        source: ${PLATFORM_DRIVE_ABCI_LOG_PRETTY_FILE_PATH:?err}
-        target: /var/log/drive-pretty.log
-      - type: bind
-        source: ${PLATFORM_DRIVE_ABCI_LOG_JSON_FILE_PATH:?err}
-        target: /var/log/drive-json.log
+      - ${PLATFORM_DRIVE_ABCI_LOG_PRETTY_FILE_PATH:?err}:/var/log/drive-pretty.log
+      - ${PLATFORM_DRIVE_ABCI_LOG_JSON_FILE_PATH:?err}:/var/log/drive-json.log
     environment:
       - CORE_JSON_RPC_USERNAME=${CORE_RPC_USER:?err}
       - CORE_JSON_RPC_PASSWORD=${CORE_RPC_PASSWORD:?err}

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -79,8 +79,8 @@ function setupLocalPresetTaskFactory(
                   config.set('platform.drive.tenderdash.p2p.port', 26656 + (i * 100));
                   config.set('platform.drive.tenderdash.rpc.port', 26657 + (i * 100));
 
-                  config.set('platform.drive.abci.log.prettyFile.path', `/tmp/drive_pretty_${nodeIndex}.log`);
-                  config.set('platform.drive.abci.log.jsonFile.path', `/tmp/drive_json_${nodeIndex}.log`);
+                  config.set('platform.drive.abci.log.prettyFile.path', `./tmp/drive_pretty_${nodeIndex}.log`);
+                  config.set('platform.drive.abci.log.jsonFile.path', `./tmp/drive_json_${nodeIndex}.log`);
                 }
               },
             }

--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -1,5 +1,7 @@
 const { Listr } = require('listr2');
 const { PRESET_LOCAL } = require('../../../constants');
+const os = require('os');
+const path = require('path');
 
 /**
  * @param {ConfigFile} configFile
@@ -79,8 +81,8 @@ function setupLocalPresetTaskFactory(
                   config.set('platform.drive.tenderdash.p2p.port', 26656 + (i * 100));
                   config.set('platform.drive.tenderdash.rpc.port', 26657 + (i * 100));
 
-                  config.set('platform.drive.abci.log.prettyFile.path', `./tmp/drive_pretty_${nodeIndex}.log`);
-                  config.set('platform.drive.abci.log.jsonFile.path', `./tmp/drive_json_${nodeIndex}.log`);
+                  config.set('platform.drive.abci.log.prettyFile.path', path.join(os.tmpdir(), `/drive_pretty_${nodeIndex}.log`));
+                  config.set('platform.drive.abci.log.jsonFile.path', path.join(os.tmpdir(), `/drive_json_${nodeIndex}.log`));
                 }
               },
             }

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const path = require('path');
+
 const { exec } = require('child_process');
 const { promisify } = require('util');
 
@@ -57,12 +59,14 @@ function startNodeTaskFactory(
       const prettyFilePath = config.get('platform.drive.abci.log.prettyFile.path');
 
       if (!fs.existsSync(prettyFilePath)) {
+        fs.mkdirSync(path.dirname(prettyFilePath), { recursive: true });
         fs.writeFileSync(prettyFilePath, '');
       }
 
       const jsonFilePath = config.get('platform.drive.abci.log.jsonFile.path');
 
       if (!fs.existsSync(jsonFilePath)) {
+        fs.mkdirSync(path.dirname(jsonFilePath), { recursive: true });
         fs.writeFileSync(jsonFilePath, '');
       }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Local windows install fails on my machine. The issue is linked to the manual absolute path '/tmp/' used to write log files. 

## What was done?

- Used `os` node package to get tmp directory based on os in use. 

## How Has This Been Tested?

- Tested locally

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
