### PR TITLE
fix: remove unneeded llmq-qvvec-sync setting 

### DIFF
--- a/templates/core/dash.conf.dot
+++ b/templates/core/dash.conf.dot
@@ -42,7 +42,6 @@ zmqpubrawtxlocksig=tcp://0.0.0.0:29998
 {{? it.network === 'testnet'}}testnet=1
 [test]
 {{?? it.network === 'local'}}
-llmq-qvvec-sync=llmq_test:0
 regtest=1
 [regtest]
 sporkaddr={{=it.core.spork.address}}

--- a/templates/core/dash.conf.dot
+++ b/templates/core/dash.conf.dot
@@ -40,7 +40,6 @@ zmqpubrawchainlocksig=tcp://0.0.0.0:29998
 zmqpubrawtxlocksig=tcp://0.0.0.0:29998
 
 {{? it.network === 'testnet'}}testnet=1
-llmq-qvvec-sync=llmq_100_67:0
 [test]
 {{?? it.network === 'local'}}
 llmq-qvvec-sync=llmq_test:0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`llmq-qvvec-sync` var is no longer required

## What was done?
<!--- Describe your changes in detail -->
Remove `llmq-qvvec-sync` logic

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested, how do I test this?

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
